### PR TITLE
Added OpenMP linking flag to cgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The <tt>go</tt> command can be used to install this package:
 
 The package documentation is available at: http://go.pkgdoc.org/github.com/danieldk/gosvm
 
+## OpenMP
+
+If you wish to use <tt>libsvm</tt> with OpenMP support for multicore processing, please use this command to install the package:
+
+    CGO_LDFLAGS="-lgomp" go get github.com/danieldk/gosvm
+
 ## Examples
 
 Examples for using gosvm can be found at:


### PR DESCRIPTION
Hi,

This is a little commit that enables the use of OpenMP-built releases of `libsvm`, typically `libsvm-openmp` package instead of `libsvm` under ArchLinux (AUR).

With that added flag, both are supported